### PR TITLE
Show "Courses" tab only for screened instructors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,7 +95,13 @@ const App: React.FC = () => {
             <PrivateRoute path="/courses/:id">
               <CourseDetail />
             </PrivateRoute>
-            <PrivateRoute path="/courses">
+            <PrivateRoute 
+              path="/courses"
+              active={
+                userContext.user.type === 'pupil' ||
+                userContext.user.instructorScreeningStatus === ScreeningStatus.Accepted
+              }
+            >
               <Course />
             </PrivateRoute>
           </Switch>

--- a/src/components/Navigation/index.tsx
+++ b/src/components/Navigation/index.tsx
@@ -18,7 +18,7 @@ interface Props {
 const Navigation: React.FC<Props> = (props) => {
   const authContext = useContext(AuthContext);
   const {
-    user: { firstname, type, screeningStatus },
+    user: { firstname, type, screeningStatus, instructorScreeningStatus },
   } = useContext(UserContext);
   const history = useHistory();
 
@@ -52,6 +52,9 @@ const Navigation: React.FC<Props> = (props) => {
         <NavButton
           to="/courses"
           icon={<Icons.Palm />}
+          active={
+            type === 'pupil' || instructorScreeningStatus === ScreeningStatus.Accepted
+          }
           onClick={() => props.setMenuOpen(false)}
         >
           Kurse

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -14,6 +14,7 @@ export const defaultUser = {
   type: 'student' as const,
   matchesRequested: 0,
   screeningStatus: ScreeningStatus.Accepted,
+  instructorScreeningStatus: ScreeningStatus.Accepted,
   matches: [
     {
       firstname: 'defaultPupilFirstname',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,7 @@ export interface User {
   matches: Match[];
   dissolvedMatches: Match[];
   screeningStatus: ScreeningStatus;
+  instructorScreeningStatus: ScreeningStatus;
 }
 
 export enum ScreeningStatus {


### PR DESCRIPTION
This will use the backend functionality of corona-school/backend#90 to hide the courses tab for all students that have no successfull instructor-screening result. This way, instructors can only see the course-creation UI if they are screened successful and thus allowed to create course.