### PR TITLE
Fix certificate generation layout bug in legacy Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "moment": "^2.26.0",
     "node-sass": "^4.14.1",
     "react": "^16.13.1",
+    "react-app-polyfill": "^1.0.6",
     "react-dom": "^16.13.1",
     "react-https-redirect": "^1.1.0",
     "react-router-dom": "^5.1.2",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,5 @@
+import 'react-app-polyfill/ie11';
+import 'react-app-polyfill/stable';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import 'antd/dist/antd.css';


### PR DESCRIPTION
This will fix corona-school/project-user#127 which occurred in legacy Edge browser.

**The problem:** The newline `\n` character that separates the different activities wasn’t appropriately encoded in the url (it was just ommited). This is the reason why there was no new line between the different activities in the generated certificate, it was just ommited…

**The solution:** Introduce ugly polyfills which fill fix the problem. This is ugly, but I think this is the only way to get appropriately designed certificates in legacy Edge. 