### PR TITLE
Small touchups to Certificate UI

### DIFF
--- a/src/components/Modals/CerificateModal.tsx
+++ b/src/components/Modals/CerificateModal.tsx
@@ -346,8 +346,8 @@ function InformationStep({
               updateData({
                 pupil,
                 subjects: [],
-                /* reset as otherwise an invalid value for the end date may occur 
-                    if the current endDate value from a previously selected is before the 
+                /* reset as otherwise an invalid value for the end date may occur
+                    if the current endDate value from a previously selected is before the
                     startdate that was currently set */
                 endDate: moment().unix(),
               });
@@ -464,7 +464,6 @@ function InformationStep({
         <WorkloadInput
           hoursPerWeek={hoursPerWeek}
           hoursTotal={hoursTotal}
-          isWorkloadAllowed={isWorkloadAllowed}
           updateData={updateData}
           weekCount={weekCount}
         />
@@ -478,12 +477,10 @@ function WorkloadInput({
   hoursTotal,
   weekCount,
   updateData,
-  isWorkloadAllowed,
 }: {
   weekCount: number;
   hoursPerWeek: number;
   hoursTotal: number;
-  isWorkloadAllowed: boolean;
   updateData(data: Partial<CertificateData>);
 }) {
   const toQuarters = (it: number) => Math.round(it * 4) / 4;
@@ -513,11 +510,8 @@ function WorkloadInput({
           value={hoursPerWeek}
           onChange={setHoursPerWeek}
           disabled={!weekCount}
-          className={
-            !isWorkloadAllowed ? classes.workloadInputFieldError : null
-          }
         />{' '}
-        h/Woche
+        h/Woche durchschnittlich
       </div>
       <div className={classes.inputField}>
         <InputNumber
@@ -527,9 +521,6 @@ function WorkloadInput({
           value={hoursTotal}
           onChange={setHoursTotal}
           disabled={!weekCount}
-          className={
-            !isWorkloadAllowed ? classes.workloadInputFieldError : null
-          }
         />{' '}
         h insgesamt
       </div>

--- a/src/components/cards/CertificateCard.tsx
+++ b/src/components/cards/CertificateCard.tsx
@@ -2,6 +2,7 @@ import { Button, Select, Space, Tag } from 'antd';
 import React, { useContext, useState } from 'react';
 import styled from 'styled-components';
 import Text from 'antd/lib/typography/Text';
+import moment from 'moment';
 import {
   IExposedCertificate,
   ISupportedLanguage,
@@ -107,7 +108,7 @@ function CertificateCard({
 
           {userContext.user.isTutor &&
             certificate.state === 'awaiting-approval' && (
-              <Tag color="yellow">noch nicht bestätigt</Tag>
+              <Tag color="orange">noch nicht bestätigt</Tag>
             )}
 
           {/* <Button danger>Löschen</Button> */}
@@ -128,6 +129,10 @@ function CertificateCard({
           {userContext.user.isPupil && certificate.state === 'approved' && (
             <Tag color="green">schon bestätigt</Tag>
           )}
+          <sub>
+            erstellt am{' '}
+            {moment(certificate.certificateDate).format('DD.MM.YYYY')}
+          </sub>
         </Space>
       </StyledCard>
     </CardContainer>


### PR DESCRIPTION
- Change color from yellow to orange for better readability
- show creation date in certificate card
- remove red highlighting for invalid fields (all the other fields aren't red anyways)

(changes requested by @tobiasbork )