### PR TITLE
FIX: Prevent empty signatures

### DIFF
--- a/src/components/Modals/SignCertificateModal.tsx
+++ b/src/components/Modals/SignCertificateModal.tsx
@@ -104,7 +104,7 @@ const SignPage: React.FC<SignPageProps> = ({
   React.useEffect(() => {
     window.addEventListener('resize', updateSigned);
     return () => window.removeEventListener('resize', updateSigned);
-  }, []);
+  }, [updateSigned]);
 
   return (
     <div className={classes.signPage}>


### PR DESCRIPTION
The signature pad we use clears the canvas on resize, to avoid [having the cursor off sync](https://github.com/agilgur5/react-signature-canvas/issues/57). This behavior is quite strange, but as reinventing the whole wheel is probably out of scope, we can either choose between the cursor going off sync or the canvas being cleared when the page gets resized. I chose the later.

As we were unaware of this behavior, it is currently possible to sign, resize and submit an empty signature. This fix prevents this, and also greys out the "Abschicken" button when the page is resized.