### PR TITLE
Add: differentiate registrations of tutor and tutees in matomo

### DIFF
--- a/src/components/misc/MatomoSupport.ts
+++ b/src/components/misc/MatomoSupport.ts
@@ -32,13 +32,17 @@ export const MatomoScript = () => {
 };
 
 export const MatomoTrackRegistration = () => {
-  // old method
   window._paq.push([
     'trackEvent',
     'Formular Interaktion',
     'Registrierung Abschluss',
   ]);
+};
 
-  // testing new method
-  window._paq.push(['trackGoal', 2]);
+export const MatomoTrackTuteeRegistration = () => {
+  window._paq.push(['trackEvent', '3']);
+};
+
+export const MatomoTrackTutorRegistration = () => {
+  window._paq.push(['trackEvent', '4']);
 };

--- a/src/routes/RegisterTutee.tsx
+++ b/src/routes/RegisterTutee.tsx
@@ -31,7 +31,10 @@ import SignupContainer from '../components/container/SignupContainer';
 import AccentColorButton from '../components/button/AccentColorButton';
 import { ReactComponent as ClockIcon } from '../assets/icons/clock-regular.svg';
 import { ReactComponent as MagicIcon } from '../assets/icons/magic-solid.svg';
-import { MatomoTrackRegistration } from '../components/misc/MatomoSupport';
+import {
+  MatomoTrackRegistration,
+  MatomoTrackTuteeRegistration,
+} from '../components/misc/MatomoSupport';
 import { disadvantageAdvice } from '../assets/registrationAssets';
 
 const { Option } = Select;
@@ -716,6 +719,7 @@ const RegisterTutee: React.FC<Props> = ({
         });
         form.resetFields();
         MatomoTrackRegistration();
+        MatomoTrackTuteeRegistration();
       })
       .catch((err) => {
         if (err.response?.status === 401) {

--- a/src/routes/RegisterTutor.tsx
+++ b/src/routes/RegisterTutor.tsx
@@ -21,7 +21,10 @@ import { env } from '../api/config';
 import { NoRegistration } from '../components/NoService';
 import { languageOptions } from '../assets/languages';
 import YouTubeVideo from '../components/misc/YouTubeVideo';
-import { MatomoTrackRegistration } from '../components/misc/MatomoSupport';
+import {
+  MatomoTrackRegistration,
+  MatomoTrackTutorRegistration,
+} from '../components/misc/MatomoSupport';
 import { DeclarationOfSelfCommitment } from '../components/forms/registration/DeclarationOfSelfCommitment';
 // import { introductionText } from '../assets/coDuAssets';
 
@@ -787,6 +790,7 @@ const RegisterTutor: React.FC<Props> = (props) => {
         setLoading(false);
         setFormState('done');
         MatomoTrackRegistration();
+        MatomoTrackTutorRegistration();
       })
       .catch((err) => {
         if (err?.response?.status === 401) {


### PR DESCRIPTION
Added two more goals to the Matomo Goal Conversion dashboard to differentiate between Tutor and Tutee registrations.
These will be triggered by the current changes.